### PR TITLE
Add Graph Neural Operator layers

### DIFF
--- a/physicsnemo/models/gno/__init__.py
+++ b/physicsnemo/models/gno/__init__.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .gno_block import GNOBlock
+from .integral_transform import IntegralTransform
+from .neighbor_search import NeighborSearch
+from .embeddings import SinusoidalEmbedding
+from .channel_mlp import LinearChannelMLP
+from .segment_csr import segment_csr
+
+__all__ = [
+    "GNOBlock",
+    "IntegralTransform",
+    "NeighborSearch",
+    "SinusoidalEmbedding",
+    "LinearChannelMLP",
+    "segment_csr",
+]

--- a/physicsnemo/models/gno/channel_mlp.py
+++ b/physicsnemo/models/gno/channel_mlp.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Channel-wise multilayer perceptron used in :class:`GNOBlock`."""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, List
+
+import torch
+from torch import nn
+
+
+class LinearChannelMLP(nn.Module):
+    """Channel MLP operating only on feature channels.
+
+    Parameters
+    ----------
+    layers : Iterable[int]
+        Sequence of layer widths. First element is input dimension and last
+        element is output dimension.
+    non_linearity : Callable, optional
+        Activation function used between linear layers, by default
+        :func:`torch.nn.functional.gelu`.
+    """
+
+    def __init__(self, layers: Iterable[int], non_linearity: Callable = nn.GELU()) -> None:
+        super().__init__()
+        layers = list(layers)
+        assert len(layers) >= 2, "At least two layers required"
+        self.in_channels = layers[0]
+        self.out_channels = layers[-1]
+        self.fcs = nn.ModuleList(
+            [nn.Linear(in_c, out_c) for in_c, out_c in zip(layers[:-1], layers[1:])]
+        )
+        self.act = non_linearity
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for i, layer in enumerate(self.fcs):
+            x = layer(x)
+            if i < len(self.fcs) - 1:
+                x = self.act(x)
+        return x

--- a/physicsnemo/models/gno/embeddings.py
+++ b/physicsnemo/models/gno/embeddings.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sinusoidal positional embeddings."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+from torch import Tensor, nn
+
+
+class SinusoidalEmbedding(nn.Module):
+    """Compute sinusoidal embeddings for input coordinates.
+
+    Parameters
+    ----------
+    in_channels : int
+        Dimension of the input coordinate space.
+    num_frequencies : int
+        Number of sinusoidal frequencies per dimension.
+    embedding_type : Literal["transformer", "nerf"]
+        Type of embedding to compute. ``"transformer"`` follows the standard
+        transformer positional encoding formulation, while ``"nerf"`` uses the
+        NeRF-style frequency embedding. Default is ``"transformer"``.
+    max_positions : int, optional
+        Maximum sequence length for ``"transformer"`` embeddings. Default 10000.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        num_frequencies: int = 32,
+        embedding_type: Literal["transformer", "nerf"] = "transformer",
+        max_positions: int = 10000,
+    ) -> None:
+        super().__init__()
+        self.in_channels = in_channels
+        self.num_frequencies = num_frequencies
+        self.embedding_type = embedding_type
+        self.max_positions = max_positions
+
+        if self.embedding_type not in {"transformer", "nerf"}:
+            raise ValueError(
+                f"embedding_type must be 'transformer' or 'nerf', got {embedding_type}"
+            )
+
+        if self.embedding_type == "transformer":
+            self.out_channels = 2 * num_frequencies * in_channels
+        else:
+            self.out_channels = 2 * num_frequencies * in_channels
+
+    def forward(self, x: Tensor) -> Tensor:  # [*, in_channels]
+        if self.embedding_type == "transformer":
+            device = x.device
+            half_dim = self.num_frequencies
+            freq = torch.exp(
+                -torch.arange(half_dim, dtype=x.dtype, device=device)
+                * (torch.log(torch.tensor(self.max_positions, dtype=x.dtype)) / half_dim)
+            )
+            freq = freq[None, None, :]
+            x = x.unsqueeze(-1) * freq
+            emb = torch.cat([x.sin(), x.cos()], dim=-1)
+            return emb.view(*x.shape[:-2], -1)
+        else:  # nerf
+            device = x.device
+            freq = 2.0 ** torch.arange(
+                self.num_frequencies, dtype=x.dtype, device=device
+            )
+            freq = freq.view([1] * (x.ndim - 1) + [self.num_frequencies])
+            x = x.unsqueeze(-1) * freq * torch.pi
+            emb = torch.cat([torch.sin(x), torch.cos(x)], dim=-1)
+            return emb.view(*x.shape[:-2], -1)

--- a/physicsnemo/models/gno/gno_block.py
+++ b/physicsnemo/models/gno/gno_block.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Graph Neural Operator block."""
+
+from __future__ import annotations
+
+from typing import Callable, List, Literal, Optional
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+from .channel_mlp import LinearChannelMLP
+from .integral_transform import IntegralTransform
+from .neighbor_search import NeighborSearch
+from .embeddings import SinusoidalEmbedding
+
+
+class GNOBlock(nn.Module):
+    """Graph Neural Operator layer."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        coord_dim: int,
+        radius: float,
+        transform_type: str = "linear",
+        weighting_fn: Optional[Callable] = None,
+        reduction: Literal["sum", "mean"] = "sum",
+        pos_embedding_type: str = "transformer",
+        pos_embedding_channels: int = 32,
+        pos_embedding_max_positions: int = 10000,
+        channel_mlp_layers: List[int] | None = None,
+        channel_mlp_non_linearity: Callable = F.gelu,
+        channel_mlp: nn.Module | None = None,
+        use_torch_scatter_reduce: bool = True,
+        use_open3d_neighbor_search: bool = True,
+    ) -> None:
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.coord_dim = coord_dim
+        self.radius = radius
+
+        self.pos_embedding_type = pos_embedding_type
+        if pos_embedding_type in {"nerf", "transformer"}:
+            self.pos_embedding = SinusoidalEmbedding(
+                in_channels=coord_dim,
+                num_frequencies=pos_embedding_channels,
+                embedding_type=pos_embedding_type,
+                max_positions=pos_embedding_max_positions,
+            )
+        else:
+            self.pos_embedding = None
+
+        if use_open3d_neighbor_search:
+            assert (
+                self.coord_dim == 3
+            ), f"open3d only supports 3D data, got {coord_dim}"
+        self.neighbor_search = NeighborSearch(
+            use_open3d=use_open3d_neighbor_search, return_norm=weighting_fn is not None
+        )
+
+        if self.pos_embedding is None:
+            kernel_in_dim = self.coord_dim * 2
+            kernel_in_dim_str = "dim(y) + dim(x)"
+        else:
+            kernel_in_dim = self.pos_embedding.out_channels * 2
+            kernel_in_dim_str = "dim(y_embed) + dim(x_embed)"
+
+        if transform_type in {"nonlinear", "nonlinear_kernelonly"}:
+            kernel_in_dim += self.in_channels
+            kernel_in_dim_str += " + dim(f_y)"
+
+        if channel_mlp is not None:
+            if channel_mlp.in_channels != kernel_in_dim:
+                raise ValueError(
+                    f"ChannelMLP expects {kernel_in_dim} channels ({kernel_in_dim_str}), got {channel_mlp.in_channels}"
+                )
+            if channel_mlp.out_channels != out_channels:
+                raise ValueError(
+                    f"ChannelMLP output channels must be {out_channels}, got {channel_mlp.out_channels}"
+                )
+        elif channel_mlp_layers is not None:
+            if channel_mlp_layers[0] != kernel_in_dim:
+                channel_mlp_layers = [kernel_in_dim] + list(channel_mlp_layers)
+            if channel_mlp_layers[-1] != out_channels:
+                channel_mlp_layers.append(out_channels)
+            channel_mlp = LinearChannelMLP(
+                layers=channel_mlp_layers, non_linearity=channel_mlp_non_linearity
+            )
+        else:
+            raise ValueError("Either channel_mlp or channel_mlp_layers must be provided")
+
+        self.integral_transform = IntegralTransform(
+            channel_mlp=channel_mlp,
+            transform_type=transform_type,
+            use_torch_scatter=use_torch_scatter_reduce,
+            weighting_fn=weighting_fn,
+            reduction=reduction,
+        )
+
+    def forward(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        f_y: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Compute the operator output."""
+        neighbors_dict = self.neighbor_search(data=y, queries=x, radius=self.radius)
+
+        if self.pos_embedding is not None:
+            y_embed = self.pos_embedding(y)
+            x_embed = self.pos_embedding(x)
+        else:
+            y_embed = y
+            x_embed = x
+
+        out_features = self.integral_transform(
+            y=y_embed,
+            x=x_embed,
+            neighbors=neighbors_dict,
+            f_y=f_y,
+        )
+        return out_features

--- a/physicsnemo/models/gno/integral_transform.py
+++ b/physicsnemo/models/gno/integral_transform.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Kernel integral transform used in :class:`GNOBlock`."""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, Optional
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+from .channel_mlp import LinearChannelMLP
+from .segment_csr import segment_csr
+
+
+class IntegralTransform(nn.Module):
+    """Integral kernel transform."""
+
+    def __init__(
+        self,
+        channel_mlp: Optional[nn.Module] = None,
+        channel_mlp_layers: Optional[Iterable[int]] = None,
+        channel_mlp_non_linearity: Callable = F.gelu,
+        transform_type: str = "linear",
+        weighting_fn: Optional[Callable] = None,
+        reduction: str = "sum",
+        use_torch_scatter: bool = True,
+    ) -> None:
+        super().__init__()
+        if channel_mlp is None and channel_mlp_layers is None:
+            raise ValueError("channel_mlp or channel_mlp_layers must be provided")
+
+        self.reduction = reduction
+        self.transform_type = transform_type
+        self.use_torch_scatter = use_torch_scatter
+        if transform_type not in {
+            "linear_kernelonly",
+            "linear",
+            "nonlinear_kernelonly",
+            "nonlinear",
+        }:
+            raise ValueError(
+                "transform_type must be one of linear_kernelonly, linear, "
+                "nonlinear_kernelonly, nonlinear"
+            )
+
+        if channel_mlp is None:
+            self.channel_mlp = LinearChannelMLP(
+                layers=channel_mlp_layers, non_linearity=channel_mlp_non_linearity
+            )
+        else:
+            self.channel_mlp = channel_mlp
+
+        self.weighting_fn = weighting_fn
+
+    def forward(
+        self,
+        y: torch.Tensor,
+        neighbors: dict,
+        x: torch.Tensor | None = None,
+        f_y: torch.Tensor | None = None,
+        weights: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Apply the integral transform."""
+        if x is None:
+            x = y
+
+        rep_features = y[neighbors["neighbors_index"]]
+
+        batched = False
+        if f_y is not None:
+            if f_y.ndim == 3:
+                batched = True
+                batch_size = f_y.shape[0]
+                in_features = f_y[:, neighbors["neighbors_index"], :]
+            elif f_y.ndim == 2:
+                in_features = f_y[neighbors["neighbors_index"]]
+            else:
+                raise ValueError("f_y must have 2 or 3 dimensions")
+
+        num_reps = neighbors["neighbors_row_splits"][1:] - neighbors["neighbors_row_splits"][:-1]
+        self_features = torch.repeat_interleave(x, num_reps, dim=0)
+
+        agg_features = torch.cat([rep_features, self_features], dim=-1)
+        if f_y is not None and self.transform_type in {"nonlinear_kernelonly", "nonlinear"}:
+            if batched:
+                agg_features = agg_features.repeat([batch_size] + [1] * agg_features.ndim)
+            agg_features = torch.cat([agg_features, in_features], dim=-1)
+
+        rep_features = self.channel_mlp(agg_features)
+
+        if f_y is not None and self.transform_type != "nonlinear_kernelonly":
+            if rep_features.ndim == 2 and batched:
+                rep_features = rep_features.unsqueeze(0).repeat([batch_size] + [1] * rep_features.ndim)
+            rep_features.mul_(in_features)
+
+        nbr_weights = neighbors.get("weights")
+        if nbr_weights is None:
+            nbr_weights = weights
+        if nbr_weights is None and self.weighting_fn is not None:
+            raise KeyError(
+                "if a weighting function is provided, your neighborhoods must contain weights."
+            )
+        if nbr_weights is not None:
+            nbr_weights = nbr_weights.unsqueeze(-1).unsqueeze(0)
+            if self.weighting_fn is not None:
+                nbr_weights = self.weighting_fn(nbr_weights)
+            rep_features.mul_(nbr_weights)
+            reduction = "sum"
+        else:
+            reduction = self.reduction
+
+        splits = neighbors["neighbors_row_splits"]
+        if batched:
+            splits = splits.unsqueeze(0).repeat([batch_size] + [1] * splits.ndim)
+
+        out_features = segment_csr(rep_features, splits, reduction=reduction, use_scatter=self.use_torch_scatter)
+        return out_features

--- a/physicsnemo/models/gno/neighbor_search.py
+++ b/physicsnemo/models/gno/neighbor_search.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Neighborhood search utilities for :class:`GNOBlock`."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import torch
+from torch import Tensor, nn
+
+# Optional open3d support
+open3d_built = False
+try:  # pragma: no cover - optional dependency
+    from open3d.ml.torch.layers import FixedRadiusSearch
+
+    open3d_built = True
+except Exception:  # pragma: no cover - optional dependency
+    pass
+
+
+class NeighborSearch(nn.Module):
+    """Neighborhood search between two coordinate meshes."""
+
+    def __init__(self, use_open3d: bool = True, return_norm: bool = False) -> None:
+        super().__init__()
+        if use_open3d and open3d_built:
+            self.search_fn = FixedRadiusSearch()
+            self.use_open3d = True
+        else:
+            self.search_fn = native_neighbor_search
+            self.use_open3d = False
+        self.return_norm = return_norm
+
+    def forward(self, data: Tensor, queries: Tensor, radius: float) -> Dict[str, Tensor]:
+        """Return neighbors within ``radius`` of each query point."""
+        if self.use_open3d:
+            search_return = self.search_fn(data, queries, radius)
+            return {
+                "neighbors_index": search_return.neighbors_index.long(),
+                "neighbors_row_splits": search_return.neighbors_row_splits.long(),
+            }
+        return self.search_fn(data, queries, radius, self.return_norm)
+
+
+def native_neighbor_search(
+    data: Tensor, queries: Tensor, radius: float, return_norm: bool = False
+) -> Dict[str, Tensor]:
+    """Pure PyTorch radius-based neighbor search."""
+    nbr_dict: Dict[str, Tensor] = {}
+    dists = torch.cdist(queries, data)
+    eps = 1e-7
+    dists = torch.where(dists == 0.0, eps, dists)
+    mask = dists <= radius
+    nbr_indices = mask.nonzero(as_tuple=False)[:, 1]
+    if return_norm:
+        weights = dists[mask]
+        nbr_dict["weights"] = weights**2
+    in_nbr = mask.to(data.dtype)
+    nbrhd_sizes = torch.cumsum(in_nbr.sum(dim=1), dim=0)
+    splits = torch.cat((torch.tensor([0.0], device=data.device), nbrhd_sizes))
+
+    nbr_dict["neighbors_index"] = nbr_indices.long()
+    nbr_dict["neighbors_row_splits"] = splits.long()
+    return nbr_dict

--- a/physicsnemo/models/gno/segment_csr.py
+++ b/physicsnemo/models/gno/segment_csr.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CSR segment reduction used by :class:`IntegralTransform`."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Literal
+
+import torch
+from torch import Tensor, einsum
+
+
+def segment_csr(
+    src: Tensor,
+    indptr: Tensor,
+    reduction: Literal["mean", "sum"],
+    use_scatter: bool = True,
+) -> Tensor:
+    """Reduce features over CSR segments."""
+    if reduction not in {"mean", "sum"}:
+        raise ValueError("reduction must be 'mean' or 'sum'")
+
+    if importlib.util.find_spec("torch_scatter") is not None and use_scatter:
+        from torch_scatter import segment_csr as scatter_segment_csr
+
+        return scatter_segment_csr(src, indptr, reduce=reduction)
+
+    if use_scatter:
+        print(
+            "Warning: use_scatter is True but torch_scatter is not available; falling back to a slower implementation",
+        )
+
+    batched = src.ndim == 3
+    point_dim = 1 if batched else 0
+    output_shape = list(src.shape)
+    n_out = indptr.shape[point_dim] - 1
+    output_shape[point_dim] = n_out
+    out = torch.zeros(output_shape, device=src.device)
+
+    for i in range(n_out):
+        if batched:
+            from_idx = (slice(None), slice(indptr[0, i], indptr[0, i + 1]))
+            ein_str = "bio->bo"
+            start = indptr[0, i]
+            n_nbrs = indptr[0, i + 1] - start
+            to_idx = (slice(None), i)
+        else:
+            from_idx = slice(indptr[i], indptr[i + 1])
+            ein_str = "io->o"
+            start = indptr[i]
+            n_nbrs = indptr[i + 1] - start
+            to_idx = i
+
+        src_from = src[from_idx]
+        if n_nbrs > 0:
+            to_reduce = einsum(ein_str, src_from)
+            if reduction == "mean":
+                to_reduce /= n_nbrs
+            out[to_idx] += to_reduce
+
+    return out


### PR DESCRIPTION
## Summary
- add Graph Neural Operator block and related utilities under `physicsnemo.models.gno`
- provide channel MLP, sinusoidal embeddings, neighbor search, integral transform and CSR reduction

## Testing
- `pytest -k gno -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pre-commit` *(fails: pre-commit not installed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68829bd54300832b8a22b4e2a0afd711